### PR TITLE
Fix (hopefully) of tinyMCE transcription field not saving properly

### DIFF
--- a/app/templates/record_edit.html
+++ b/app/templates/record_edit.html
@@ -85,7 +85,9 @@
                     <br />
                 <textarea class="form-control" id="transcription"></textarea>
             </div>
-            <button type="submit" class="btn btn-primary" id="rec_update">Update</button>
+            <button type="submit" class="btn btn-primary" id="rec_update" onclick="tinyMCE.triggerSave()">
+                Update
+            </button>
         </form>
     </div>
     {% if rec %}


### PR DESCRIPTION

Added an onclick handler on the form submit button that sets TinyMCE up for saving; currently the transcription field is not being updated. TinyMCE should be doing this automatically, but it's not, apparently.